### PR TITLE
Broken link fixed. Naming convention.

### DIFF
--- a/api/rest/openapi.yaml
+++ b/api/rest/openapi.yaml
@@ -84,7 +84,7 @@ paths:
         https://iss.moex.com/iss/engines/stock/markets/shares/boards/tqbr/securities.json
         ```
         
-        [описание метрик](../des/realtime#marketstatistics) | [Кастомизация запросов](/api_custom)
+        [Описание метрик](/des/realtime#marketstatistics) | [Кастомизация запросов](/api_custom)
         
         <details><summary>
         пример ответа


### PR DESCRIPTION
1. Далее в файле еще много мест, где используется эта же неработающая ссылка. Посмотрите там сами.

2. Будет хорошо применить единый подход к именованию ссылок: либо все строчными, либо начинать с заглавной буквы. 
Cейчас в тексте встречаются ссылки: описание метрик | Кастомизация запросов 
Было бы нормально все написать строчными буквами: описание метрик | кастомизация запросов 
либо каждую ссылку начинать с заглавной: Описание метрик | Кастомизация запросов 
Рекомендую второе.
Грамотно оформленная документация - основа доверия :-) 